### PR TITLE
Audit take 2

### DIFF
--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -56,10 +56,16 @@ contract RewardsDistributor is IRewardDistributor {
             revert AccessError.Unauthorized(msg.sender);
         }
         if (poolId_ != poolId) {
-            revert ParameterError.InvalidParameter("poolId", "Unexpected pool");
+            revert ParameterError.InvalidParameter(
+                "poolId",
+                "Pool does not match the rewards pool"
+            );
         }
         if (collateralType_ != collateralType) {
-            revert ParameterError.InvalidParameter("collateralType", "Unexpected collateral");
+            revert ParameterError.InvalidParameter(
+                "collateralType",
+                "Collateral does not match the rewards token"
+            );
         }
         collateralType.safeTransfer(payoutTarget_, payoutAmount_);
         return true;
@@ -76,10 +82,16 @@ contract RewardsDistributor is IRewardDistributor {
             revert AccessError.Unauthorized(msg.sender);
         }
         if (poolId_ != poolId) {
-            revert ParameterError.InvalidParameter("poolId", "Unexpected pool");
+            revert ParameterError.InvalidParameter(
+                "poolId",
+                "Pool does not match the rewards pool"
+            );
         }
         if (collateralType_ != collateralType) {
-            revert ParameterError.InvalidParameter("collateralType", "Unexpected collateral");
+            revert ParameterError.InvalidParameter(
+                "collateralType",
+                "Collateral does not match the rewards token"
+            );
         }
         ISynthetixCore(rewardManager).distributeRewards(
             poolId_,

--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -43,8 +43,8 @@ contract RewardsDistributor is IRewardDistributor {
 
     function payout(
         uint128, // accountId,
-        uint128, // poolId,
-        address, // collateralType,
+        uint128 poolId_,
+        address collateralType_,
         address payoutTarget_, // msg.sender of claimRewards() call, payout target address
         uint256 payoutAmount_
     ) external returns (bool) {
@@ -54,6 +54,12 @@ contract RewardsDistributor is IRewardDistributor {
         // IMPORTANT: In production, this function should revert if msg.sender is not the Synthetix CoreProxy address.
         if (msg.sender != rewardManager) {
             revert AccessError.Unauthorized(msg.sender);
+        }
+        if (poolId_ != poolId) {
+            revert ParameterError.InvalidParameter("poolId", "Unexpected pool");
+        }
+        if (collateralType_ != collateralType) {
+            revert ParameterError.InvalidParameter("collateralType", "Unexpected collateral");
         }
         collateralType.safeTransfer(payoutTarget_, payoutAmount_);
         return true;

--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -11,7 +11,7 @@ import {ISynthetixCore} from "./interfaces/ISynthetixCore.sol";
 contract RewardsDistributor is IRewardDistributor {
     using ERC20Helper for address;
 
-    address private rewardManager;
+    address public rewardManager;
     uint128 public poolId;
     address public collateralType;
     string public name;

--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -4,11 +4,13 @@ pragma solidity ^0.8.13;
 import {IRewardDistributor} from "@synthetixio/main/contracts/interfaces/external/IRewardDistributor.sol";
 import {AccessError} from "@synthetixio/core-contracts/contracts/errors/AccessError.sol";
 import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
-import {IERC20} from "@synthetixio/core-contracts/contracts/interfaces/IERC20.sol";
+import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import {IERC165} from "@synthetixio/core-contracts/contracts/interfaces/IERC165.sol";
 import {ISynthetixCore} from "./interfaces/ISynthetixCore.sol";
 
 contract RewardsDistributor is IRewardDistributor {
+    using ERC20Helper for address;
+
     address private rewardManager;
     uint128 public poolId;
     address public collateralType;
@@ -53,7 +55,7 @@ contract RewardsDistributor is IRewardDistributor {
         if (msg.sender != rewardManager) {
             revert AccessError.Unauthorized(msg.sender);
         }
-        IERC20(collateralType).transfer(payoutTarget_, payoutAmount_);
+        collateralType.safeTransfer(payoutTarget_, payoutAmount_);
         return true;
     }
 

--- a/src/SnapshotRewardsDistributor.sol
+++ b/src/SnapshotRewardsDistributor.sol
@@ -77,11 +77,17 @@ contract SnapshotRewardsDistributor is IRewardDistributor, ISnapshotRecord {
         }
 
         if (poolId != servicePoolId) {
-            revert ParameterError.InvalidParameter("poolId", "Unexpected pool");
+            revert ParameterError.InvalidParameter(
+                "poolId",
+                "Pool does not match the rewards pool"
+            );
         }
 
         if (collateralType != serviceCollateralType) {
-            revert ParameterError.InvalidParameter("collateralType", "Unexpected collateral");
+            revert ParameterError.InvalidParameter(
+                "collateralType",
+                "Collateral does not match the rewards token"
+            );
         }
 
         // get current account information

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -42,7 +42,9 @@ contract CoreProxyMock {
         duration = duration_;
     }
 
-    function getPoolOwner(uint128 poolId_) public view returns (address) {
+    function getPoolOwner(
+        uint128 // poolId_
+    ) public view returns (address) {
         return address(this);
     }
 }
@@ -65,6 +67,7 @@ contract RewardsDistributorTest is Test {
     }
 
     function test_constructor_arguments() public {
+        assertEq(rewardsDistributor.rewardManager(), address(rewardsManager));
         assertEq(rewardsDistributor.name(), "whatever");
         assertEq(rewardsDistributor.collateralType(), address(fakeSnxToken));
         assertEq(rewardsDistributor.token(), address(fakeSnxToken));

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -110,6 +110,48 @@ contract RewardsDistributorTest is Test {
         vm.stopPrank();
     }
 
+    function test_payout_WrongPool() public {
+        fakeSnxToken.mint(address(rewardsDistributor), 1000e18);
+        vm.startPrank(address(rewardsManager));
+        vm.deal(address(rewardsManager), 1 ether);
+        uint128 accountId = 1;
+        uint128 poolId = 2;
+        address collateralType = address(fakeSnxToken);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ParameterError.InvalidParameter.selector,
+                "poolId",
+                "Unexpected pool"
+            )
+        );
+        assertEq(
+            rewardsDistributor.payout(accountId, poolId, collateralType, vm.addr(0xB0B), 10e18),
+            false
+        );
+        vm.stopPrank();
+    }
+
+    function test_payout_WrongCollateralType() public {
+        fakeSnxToken.mint(address(rewardsDistributor), 1000e18);
+        vm.startPrank(address(rewardsManager));
+        vm.deal(address(rewardsManager), 1 ether);
+        uint128 accountId = 1;
+        uint128 poolId = 1;
+        address collateralType = address(0xB0B);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ParameterError.InvalidParameter.selector,
+                "collateralType",
+                "Unexpected collateral"
+            )
+        );
+        assertEq(
+            rewardsDistributor.payout(accountId, poolId, collateralType, vm.addr(0xB0B), 10e18),
+            false
+        );
+        vm.stopPrank();
+    }
+
     function test_payout_underflow() public {
         vm.startPrank(address(rewardsManager));
         vm.deal(address(rewardsManager), 1 ether);

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -124,7 +124,7 @@ contract RewardsDistributorTest is Test {
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
                 "poolId",
-                "Unexpected pool"
+                "Pool does not match the rewards pool"
             )
         );
         assertEq(
@@ -145,7 +145,7 @@ contract RewardsDistributorTest is Test {
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
                 "collateralType",
-                "Unexpected collateral"
+                "Collateral does not match the rewards token"
             )
         );
         assertEq(
@@ -248,7 +248,7 @@ contract RewardsDistributorTest is Test {
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
                 "poolId",
-                "Unexpected pool"
+                "Pool does not match the rewards pool"
             )
         );
         rewardsDistributor.distributeRewards(poolId, collateralType, amount, start, duration);
@@ -268,7 +268,7 @@ contract RewardsDistributorTest is Test {
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
                 "collateralType",
-                "Unexpected collateral"
+                "Collateral does not match the rewards token"
             )
         );
         rewardsDistributor.distributeRewards(poolId, collateralType, amount, start, duration);

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -9,6 +9,7 @@ import {IRewardsManagerModule} from "@synthetixio/main/contracts/interfaces/IRew
 import {IRewardDistributor} from "@synthetixio/main/contracts/interfaces/external/IRewardDistributor.sol";
 import {AccessError} from "@synthetixio/core-contracts/contracts/errors/AccessError.sol";
 import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
+import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 
 contract FakeSNX is MockERC20 {
     constructor() {
@@ -114,7 +115,14 @@ contract RewardsDistributorTest is Test {
         vm.deal(address(rewardsManager), 1 ether);
         uint128 accountId = 1;
         uint128 poolId = 1;
-        vm.expectRevert(bytes("ERC20: subtraction underflow"));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC20Helper.FailedTransfer.selector,
+                address(rewardsDistributor),
+                vm.addr(0xB0B),
+                10e18
+            )
+        );
         assertEq(
             rewardsDistributor.payout(
                 accountId,

--- a/test/SnapshotRewardsDistributorUnitTest.sol
+++ b/test/SnapshotRewardsDistributorUnitTest.sol
@@ -148,7 +148,7 @@ contract SnapshotRewardsDistributorUnitTest is Test {
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
                 "poolId",
-                "Unexpected pool"
+                "Pool does not match the rewards pool"
             )
         );
         rewardsDistributor.onPositionUpdated(accountId, poolId, collateralType, 123);
@@ -166,7 +166,7 @@ contract SnapshotRewardsDistributorUnitTest is Test {
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
                 "collateralType",
-                "Unexpected collateral"
+                "Collateral does not match the rewards token"
             )
         );
         rewardsDistributor.onPositionUpdated(accountId, poolId, collateralType, actorSharesD18);


### PR DESCRIPTION
- IERC20.transfer -> ERC20Helper.safeTransfer
- Verify `pool` and `collateralType` during payout
- Make rewardManager public
- Verify `pool` and `collateralType` during `distributeReward` to match constructor args
