### PR TITLE
Cover case when payout token is different from collateral token

### DIFF
--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -14,6 +14,7 @@ contract RewardsDistributor is IRewardDistributor {
     address public rewardManager;
     uint128 public poolId;
     address public collateralType;
+    address public payoutToken;
     string public name;
 
     bool public shouldFailPayout;
@@ -22,16 +23,18 @@ contract RewardsDistributor is IRewardDistributor {
         address rewardManager_,
         uint128 poolId_,
         address collateralType_,
+        address payoutToken_,
         string memory name_
     ) {
         rewardManager = rewardManager_; // Synthetix CoreProxy
         poolId = poolId_;
         collateralType = collateralType_;
+        payoutToken = payoutToken_;
         name = name_;
     }
 
     function token() public view returns (address) {
-        return collateralType;
+        return payoutToken;
     }
 
     function setShouldFailPayout(bool shouldFailPayout_) external {
@@ -67,7 +70,7 @@ contract RewardsDistributor is IRewardDistributor {
                 "Collateral does not match the rewards token"
             );
         }
-        collateralType.safeTransfer(payoutTarget_, payoutAmount_);
+        payoutToken.safeTransfer(payoutTarget_, payoutAmount_);
         return true;
     }
 


### PR DESCRIPTION
When payout token differs from pool collateral that is tracked we want to distribute payout token and not pool collateral.

In https://sips.synthetix.io/stps/stp-14/ it is expected to distribute SNX token for LP providers to the pool that only has sUSDC (and snxUSD) collateral tokens. SNX token that will be distributed during the payout is not a pool collateral (sUSDC)