### PR TITLE
Non-18 payout token decimals

### DIFF
--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -19,7 +19,7 @@ contract RewardsDistributor is IRewardDistributor {
     string public name;
 
     uint256 public precision;
-    uint256 public SYSTEM_PRECISION = 10 ** 18;
+    uint256 public constant SYSTEM_PRECISION = 10 ** 18;
 
     bool public shouldFailPayout;
 

--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -6,6 +6,7 @@ import {AccessError} from "@synthetixio/core-contracts/contracts/errors/AccessEr
 import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
 import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import {IERC165} from "@synthetixio/core-contracts/contracts/interfaces/IERC165.sol";
+import {IERC20} from "@synthetixio/core-contracts/contracts/interfaces/IERC20.sol";
 import {ISynthetixCore} from "./interfaces/ISynthetixCore.sol";
 
 contract RewardsDistributor is IRewardDistributor {
@@ -70,7 +71,12 @@ contract RewardsDistributor is IRewardDistributor {
                 "Collateral does not match the rewards token"
             );
         }
-        payoutToken.safeTransfer(payoutTarget_, payoutAmount_);
+
+        // payoutAmount_ is always in 18 decimals precision, adjust actual payout amount to match payout token decimals
+        uint256 systemPrecision = 10 ** 18;
+        uint256 payoutPrecision = 10 ** IERC20(payoutToken).decimals();
+        uint256 adjustedAmount = (payoutAmount_ / systemPrecision) * payoutPrecision;
+        payoutToken.safeTransfer(payoutTarget_, adjustedAmount);
         return true;
     }
 

--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -74,8 +74,8 @@ contract RewardsDistributor is IRewardDistributor {
 
         // payoutAmount_ is always in 18 decimals precision, adjust actual payout amount to match payout token decimals
         uint256 systemPrecision = 10 ** 18;
-        uint256 payoutPrecision = 10 ** IERC20(payoutToken).decimals();
-        uint256 adjustedAmount = (payoutAmount_ / systemPrecision) * payoutPrecision;
+        uint256 distributorPrecision = 10 ** IERC20(payoutToken).decimals();
+        uint256 adjustedAmount = (payoutAmount_ / systemPrecision) * distributorPrecision;
         payoutToken.safeTransfer(payoutTarget_, adjustedAmount);
         return true;
     }
@@ -102,10 +102,17 @@ contract RewardsDistributor is IRewardDistributor {
                 "Collateral does not match the rewards token"
             );
         }
+
+        // amount_ is in payout token decimals precision, adjust actual distribution amount to 18 decimals that core is making its calculations in
+        // this is necessary to avoid rounding issues when doing actual payouts
+        uint256 systemPrecision = 10 ** 18;
+        uint256 distributorPrecision = 10 ** IERC20(payoutToken).decimals();
+        uint256 adjustedAmount = (amount_ / distributorPrecision) * systemPrecision;
+
         ISynthetixCore(rewardManager).distributeRewards(
             poolId_,
             collateralType_,
-            amount_,
+            adjustedAmount,
             start_,
             duration_
         );

--- a/test/MintableToken.sol
+++ b/test/MintableToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {MockERC20} from "forge-std/mocks/MockERC20.sol";
+
+contract MintableToken is MockERC20 {
+    constructor(string memory _symbol, uint8 _decimals) {
+        initialize(string.concat("Mintable token ", _symbol), _symbol, _decimals);
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -15,10 +15,33 @@ contract MintableToken is MockERC20 {
     }
 }
 
-contract CoreProxyMock {}
+contract CoreProxyMock {
+    uint256 public amount;
+    function distributeRewards(
+        uint128, // poolId_,
+        address, // collateralType_,
+        uint256 amount_,
+        uint64, // start_,
+        uint32 // duration_
+    ) public {
+        amount = amount_;
+    }
+
+    address public poolOwner;
+    function getPoolOwner(
+        uint128 // poolId_
+    ) public view returns (address) {
+        return poolOwner;
+    }
+
+    constructor(address poolOwner_) {
+        poolOwner = poolOwner_;
+    }
+}
 
 contract RewardsDistributorPrecisionTest is Test {
     address private BOB;
+    address private BOSS;
 
     MintableToken internal sUSDC;
     CoreProxyMock internal rewardsManager;
@@ -29,9 +52,66 @@ contract RewardsDistributorPrecisionTest is Test {
 
     function setUp() public {
         BOB = vm.addr(0xB0B);
-        rewardsManager = new CoreProxyMock();
+        BOSS = vm.addr(0xB055);
+        rewardsManager = new CoreProxyMock(BOSS);
         sUSDC = new MintableToken("sUSDC", 18);
         collateralType = address(sUSDC);
+    }
+
+    function test_distributeRewards_lowerDecimalsToken() public {
+        MintableToken T6D = new MintableToken("T6D", 6);
+        RewardsDistributor rd = new RewardsDistributor(
+            address(rewardsManager),
+            poolId,
+            collateralType,
+            address(T6D),
+            "6 Decimals token payouts"
+        );
+        T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
+        vm.deal(address(rewardsManager), 1 ether);
+
+        assertEq(T6D.balanceOf(address(rd)), 1_000e6);
+        assertEq(T6D.balanceOf(BOB), 0);
+
+        uint64 start = 12345678;
+        uint32 duration = 3600;
+
+        uint256 amount = 100e6;
+
+        vm.startPrank(BOSS);
+        rd.distributeRewards(poolId, collateralType, amount, start, duration);
+        vm.stopPrank();
+
+        // check that rewards manager only deals with 18 decimals
+        assertEq(rewardsManager.amount(), 100e18);
+    }
+
+    function test_distributeRewards_higherDecimalsToken() public {
+        MintableToken T33D = new MintableToken("T33D", 33);
+        RewardsDistributor rd = new RewardsDistributor(
+            address(rewardsManager),
+            poolId,
+            collateralType,
+            address(T33D),
+            "33 Decimals token payouts"
+        );
+        T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
+        vm.deal(address(rewardsManager), 1 ether);
+
+        assertEq(T33D.balanceOf(address(rd)), 1_000e33);
+        assertEq(T33D.balanceOf(BOB), 0);
+
+        uint64 start = 12345678;
+        uint32 duration = 3600;
+
+        uint256 amount = 100e33;
+
+        vm.startPrank(BOSS);
+        rd.distributeRewards(poolId, collateralType, amount, start, duration);
+        vm.stopPrank();
+
+        // check that rewards manager only deals with 18 decimals
+        assertEq(rewardsManager.amount(), 100e18);
     }
 
     function test_payout_lowerDecimalsToken() public {
@@ -49,8 +129,10 @@ contract RewardsDistributorPrecisionTest is Test {
         assertEq(T6D.balanceOf(address(rd)), 1_000e6);
         assertEq(T6D.balanceOf(BOB), 0);
 
+        uint256 amount = 10e18; // Distribute 10 tokens, the number is in 18 dec precision
+
         vm.startPrank(address(rewardsManager));
-        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, 10e18)); // Distribute 10 tokens, the number is in 18 dec precision
+        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, amount));
         vm.stopPrank();
 
         assertEq(T6D.balanceOf(address(rd)), 990e6);
@@ -72,8 +154,10 @@ contract RewardsDistributorPrecisionTest is Test {
         assertEq(T33D.balanceOf(address(rd)), 1_000e33);
         assertEq(T33D.balanceOf(BOB), 0);
 
+        uint256 amount = 10e18; // Distribute 10 tokens, the number is in 18 dec precision
+
         vm.startPrank(address(rewardsManager));
-        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, 10e18)); // Distribute 10 tokens, the number is in 18 dec precision
+        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, amount));
         vm.stopPrank();
 
         assertEq(T33D.balanceOf(address(rd)), 990e33);

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "forge-std/mocks/MockERC20.sol";
+import {RewardsDistributor} from "../src/RewardsDistributor.sol";
+
+contract MintableToken is MockERC20 {
+    constructor(string memory _symbol, uint8 _decimals) {
+        initialize(string.concat("Mintable token ", _symbol), _symbol, _decimals);
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}
+
+contract CoreProxyMock {}
+
+contract RewardsDistributorPrecisionTest is Test {
+    address private BOB;
+
+    MintableToken internal sUSDC;
+    CoreProxyMock internal rewardsManager;
+
+    uint128 internal accountId = 1;
+    uint128 internal poolId = 1;
+    address internal collateralType;
+
+    function setUp() public {
+        BOB = vm.addr(0xB0B);
+        rewardsManager = new CoreProxyMock();
+        sUSDC = new MintableToken("sUSDC", 18);
+        collateralType = address(sUSDC);
+    }
+
+    function test_payout_lowerDecimalsToken() public {
+        MintableToken T6D = new MintableToken("T6D", 6);
+        RewardsDistributor rd = new RewardsDistributor(
+            address(rewardsManager),
+            poolId,
+            collateralType,
+            address(T6D),
+            "6 Decimals token payouts"
+        );
+        T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
+        vm.deal(address(rewardsManager), 1 ether);
+
+        assertEq(T6D.balanceOf(address(rd)), 1_000e6);
+        assertEq(T6D.balanceOf(BOB), 0);
+
+        vm.startPrank(address(rewardsManager));
+        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, 10e18)); // Distribute 10 tokens, the number is in 18 dec precision
+        vm.stopPrank();
+
+        assertEq(T6D.balanceOf(address(rd)), 990e6);
+        assertEq(T6D.balanceOf(BOB), 10e6);
+    }
+
+    function test_payout_higherDecimalsToken() public {
+        MintableToken T33D = new MintableToken("T33D", 33);
+        RewardsDistributor rd = new RewardsDistributor(
+            address(rewardsManager),
+            poolId,
+            collateralType,
+            address(T33D),
+            "33 Decimals token payouts"
+        );
+        T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
+        vm.deal(address(rewardsManager), 1 ether);
+
+        assertEq(T33D.balanceOf(address(rd)), 1_000e33);
+        assertEq(T33D.balanceOf(BOB), 0);
+
+        vm.startPrank(address(rewardsManager));
+        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, 10e18)); // Distribute 10 tokens, the number is in 18 dec precision
+        vm.stopPrank();
+
+        assertEq(T33D.balanceOf(address(rd)), 990e33);
+        assertEq(T33D.balanceOf(BOB), 10e33);
+    }
+}

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -41,6 +41,8 @@ contract RewardsDistributorPrecisionTest is Test {
     uint128 internal accountId = 1;
     uint128 internal poolId = 1;
     address internal collateralType;
+    uint64 internal start = 12345678;
+    uint32 internal duration = 3600;
 
     function setUp() public {
         BOB = vm.addr(0xB0B);
@@ -63,9 +65,6 @@ contract RewardsDistributorPrecisionTest is Test {
 
         assertEq(T6D.balanceOf(address(rd)), 1_000e6);
         assertEq(T6D.balanceOf(BOB), 0);
-
-        uint64 start = 12345678;
-        uint32 duration = 3600;
 
         uint256 amount = 100e6;
 
@@ -98,9 +97,6 @@ contract RewardsDistributorPrecisionTest is Test {
 
         assertEq(T33D.balanceOf(address(rd)), 1_000e33);
         assertEq(T33D.balanceOf(BOB), 0);
-
-        uint64 start = 12345678;
-        uint32 duration = 3600;
 
         uint256 amount = 100e33;
 

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -5,15 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "forge-std/mocks/MockERC20.sol";
 import {RewardsDistributor} from "../src/RewardsDistributor.sol";
 
-contract MintableToken is MockERC20 {
-    constructor(string memory _symbol, uint8 _decimals) {
-        initialize(string.concat("Mintable token ", _symbol), _symbol, _decimals);
-    }
-
-    function mint(address to, uint256 amount) public {
-        _mint(to, amount);
-    }
-}
+import {MintableToken} from "./MintableToken.sol";
 
 contract CoreProxyMock {
     uint256 public amount;

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -60,7 +60,6 @@ contract RewardsDistributorPrecisionTest is Test {
             "6 Decimals token payouts"
         );
         T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
-        vm.deal(address(rewardsManager), 1 ether);
 
         assertEq(T6D.balanceOf(address(rd)), 1_000e6);
         assertEq(T6D.balanceOf(BOB), 0);
@@ -76,6 +75,14 @@ contract RewardsDistributorPrecisionTest is Test {
 
         // check that rewards manager only deals with 18 decimals
         assertEq(rewardsManager.amount(), 100e18);
+
+        uint256 fractionAmount = 0.001e6;
+
+        vm.startPrank(BOSS);
+        rd.distributeRewards(poolId, collateralType, fractionAmount, start, duration);
+        vm.stopPrank();
+
+        assertEq(rewardsManager.amount(), 0.001e18);
     }
 
     function test_distributeRewards_higherDecimalsToken() public {
@@ -88,7 +95,6 @@ contract RewardsDistributorPrecisionTest is Test {
             "33 Decimals token payouts"
         );
         T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
-        vm.deal(address(rewardsManager), 1 ether);
 
         assertEq(T33D.balanceOf(address(rd)), 1_000e33);
         assertEq(T33D.balanceOf(BOB), 0);
@@ -104,6 +110,14 @@ contract RewardsDistributorPrecisionTest is Test {
 
         // check that rewards manager only deals with 18 decimals
         assertEq(rewardsManager.amount(), 100e18);
+
+        uint256 fractionAmount = 0.001e33;
+
+        vm.startPrank(BOSS);
+        rd.distributeRewards(poolId, collateralType, fractionAmount, start, duration);
+        vm.stopPrank();
+
+        assertEq(rewardsManager.amount(), 0.001e18);
     }
 
     function test_payout_lowerDecimalsToken() public {
@@ -116,7 +130,6 @@ contract RewardsDistributorPrecisionTest is Test {
             "6 Decimals token payouts"
         );
         T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
-        vm.deal(address(rewardsManager), 1 ether);
 
         assertEq(T6D.balanceOf(address(rd)), 1_000e6);
         assertEq(T6D.balanceOf(BOB), 0);
@@ -141,7 +154,6 @@ contract RewardsDistributorPrecisionTest is Test {
             "33 Decimals token payouts"
         );
         T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
-        vm.deal(address(rewardsManager), 1 ether);
 
         assertEq(T33D.balanceOf(address(rd)), 1_000e33);
         assertEq(T33D.balanceOf(BOB), 0);

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -11,35 +11,9 @@ import {AccessError} from "@synthetixio/core-contracts/contracts/errors/AccessEr
 import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
 import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 
-contract SynthUSDCToken is MockERC20 {
-    constructor() {
-        initialize("Synth USDC", "sUSDC", 18);
-    }
-}
-
-contract SNXToken is MockERC20 {
-    constructor() {
-        initialize("Synthetix Network Token", "SNX", 18);
-    }
-
-    function mint(address to, uint256 amount) public {
-        _mint(to, amount);
-    }
-}
-
-contract Token6Decimals is MockERC20 {
-    constructor() {
-        initialize("Token with 6 decimals", "T6D", 6);
-    }
-
-    function mint(address to, uint256 amount) public {
-        _mint(to, amount);
-    }
-}
-
-contract Token33Decimals is MockERC20 {
-    constructor() {
-        initialize("Token with 33 decimals", "T33D", 33);
+contract MintableToken is MockERC20 {
+    constructor(string memory _symbol, uint8 _decimals) {
+        initialize(string.concat("Mintable token ", _symbol), _symbol, _decimals);
     }
 
     function mint(address to, uint256 amount) public {
@@ -79,8 +53,8 @@ contract RewardsDistributorTest is Test {
     address private ALICE;
     address private BOB;
 
-    SynthUSDCToken internal sUSDC;
-    SNXToken internal SNX;
+    MintableToken internal sUSDC;
+    MintableToken internal SNX;
     RewardsDistributor internal rewardsDistributor;
     CoreProxyMock internal rewardsManager;
 
@@ -88,8 +62,8 @@ contract RewardsDistributorTest is Test {
         ALICE = vm.addr(0xA11CE);
         BOB = vm.addr(0xB0B);
 
-        SNX = new SNXToken();
-        sUSDC = new SynthUSDCToken();
+        SNX = new MintableToken("SNX", 18);
+        sUSDC = new MintableToken("sUSDC", 18);
 
         rewardsManager = new CoreProxyMock();
 
@@ -311,11 +285,11 @@ contract RewardsDistributorTest is Test {
         uint128 poolId = 1;
         address collateralType = address(sUSDC);
 
-        Token6Decimals T6D = new Token6Decimals();
+        MintableToken T6D = new MintableToken("T6D", 6);
         RewardsDistributor rd = new RewardsDistributor(
             address(rewardsManager),
             poolId,
-            address(sUSDC),
+            collateralType,
             address(T6D),
             "6 Decimals token payouts"
         );
@@ -338,11 +312,11 @@ contract RewardsDistributorTest is Test {
         uint128 poolId = 1;
         address collateralType = address(sUSDC);
 
-        Token33Decimals T33D = new Token33Decimals();
+        MintableToken T33D = new MintableToken("T33D", 33);
         RewardsDistributor rd = new RewardsDistributor(
             address(rewardsManager),
             poolId,
-            address(sUSDC),
+            collateralType,
             address(T33D),
             "33 Decimals token payouts"
         );

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -10,15 +10,7 @@ import {AccessError} from "@synthetixio/core-contracts/contracts/errors/AccessEr
 import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
 import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 
-contract MintableToken is MockERC20 {
-    constructor(string memory _symbol, uint8 _decimals) {
-        initialize(string.concat("Mintable token ", _symbol), _symbol, _decimals);
-    }
-
-    function mint(address to, uint256 amount) public {
-        _mint(to, amount);
-    }
-}
+import {MintableToken} from "./MintableToken.sol";
 
 contract CoreProxyMock {
     uint128 public poolId;

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -117,7 +117,7 @@ contract RewardsDistributorTest is Test {
     function test_payout_WrongPool() public {
         SNX.mint(address(rewardsDistributor), 1000e18);
         vm.startPrank(address(rewardsManager));
-        vm.deal(address(rewardsManager), 1 ether);
+
         uint128 accountId = 1;
         uint128 poolId = 2;
         address collateralType = address(sUSDC);
@@ -135,7 +135,7 @@ contract RewardsDistributorTest is Test {
     function test_payout_WrongCollateralType() public {
         SNX.mint(address(rewardsDistributor), 1000e18);
         vm.startPrank(address(rewardsManager));
-        vm.deal(address(rewardsManager), 1 ether);
+
         uint128 accountId = 1;
         uint128 poolId = 1;
         address collateralType = address(0); // wrong one
@@ -152,7 +152,7 @@ contract RewardsDistributorTest is Test {
 
     function test_payout_underflow() public {
         vm.startPrank(address(rewardsManager));
-        vm.deal(address(rewardsManager), 1 ether);
+
         uint128 accountId = 1;
         uint128 poolId = 1;
         address collateralType = address(sUSDC);
@@ -170,7 +170,7 @@ contract RewardsDistributorTest is Test {
 
     function test_payout_shouldFail() public {
         SNX.mint(address(rewardsDistributor), 1000e18);
-        vm.deal(address(rewardsManager), 1 ether);
+
         uint128 accountId = 1;
         uint128 poolId = 1;
         address collateralType = address(sUSDC);
@@ -186,7 +186,7 @@ contract RewardsDistributorTest is Test {
 
     function test_payout() public {
         SNX.mint(address(rewardsDistributor), 1000e18);
-        vm.deal(address(rewardsManager), 1 ether);
+
         uint128 accountId = 1;
         uint128 poolId = 1;
         address collateralType = address(sUSDC);
@@ -204,7 +204,7 @@ contract RewardsDistributorTest is Test {
         uint32 duration = 3600;
 
         vm.startPrank(ALICE);
-        vm.deal(address(rewardsManager), 1 ether);
+
         vm.expectRevert(abi.encodeWithSelector(AccessError.Unauthorized.selector, ALICE));
         rewardsDistributor.distributeRewards(poolId, collateralType, amount, start, duration);
         vm.stopPrank();
@@ -218,7 +218,7 @@ contract RewardsDistributorTest is Test {
         uint32 duration = 3600;
 
         vm.startPrank(BOSS);
-        vm.deal(address(rewardsManager), 1 ether);
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,
@@ -238,7 +238,7 @@ contract RewardsDistributorTest is Test {
         uint32 duration = 3600;
 
         vm.startPrank(BOSS);
-        vm.deal(address(rewardsManager), 1 ether);
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 ParameterError.InvalidParameter.selector,

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.21;
 
 import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "forge-std/mocks/MockERC20.sol";
-import {console2} from "forge-std/console2.sol";
 import {RewardsDistributor} from "../src/RewardsDistributor.sol";
 import {IRewardsManagerModule} from "@synthetixio/main/contracts/interfaces/IRewardsManagerModule.sol";
 import {IRewardDistributor} from "@synthetixio/main/contracts/interfaces/external/IRewardDistributor.sol";
@@ -278,59 +277,5 @@ contract RewardsDistributorTest is Test {
         assertEq(rewardsDistributor.supportsInterface(type(IRewardDistributor).interfaceId), true);
         bytes4 anotherInterface = bytes4(keccak256(bytes("123")));
         assertEq(rewardsDistributor.supportsInterface(anotherInterface), false);
-    }
-
-    function test_payout_lowerDecimalsToken() public {
-        uint128 accountId = 1;
-        uint128 poolId = 1;
-        address collateralType = address(sUSDC);
-
-        MintableToken T6D = new MintableToken("T6D", 6);
-        RewardsDistributor rd = new RewardsDistributor(
-            address(rewardsManager),
-            poolId,
-            collateralType,
-            address(T6D),
-            "6 Decimals token payouts"
-        );
-        T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
-        vm.deal(address(rewardsManager), 1 ether);
-
-        assertEq(T6D.balanceOf(address(rd)), 1_000e6);
-        assertEq(T6D.balanceOf(BOB), 0);
-
-        vm.startPrank(address(rewardsManager));
-        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, 10e18)); // Distribute 10 tokens, the number is in 18 dec precision
-        vm.stopPrank();
-
-        assertEq(T6D.balanceOf(address(rd)), 990e6);
-        assertEq(T6D.balanceOf(BOB), 10e6);
-    }
-
-    function test_payout_higherDecimalsToken() public {
-        uint128 accountId = 1;
-        uint128 poolId = 1;
-        address collateralType = address(sUSDC);
-
-        MintableToken T33D = new MintableToken("T33D", 33);
-        RewardsDistributor rd = new RewardsDistributor(
-            address(rewardsManager),
-            poolId,
-            collateralType,
-            address(T33D),
-            "33 Decimals token payouts"
-        );
-        T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
-        vm.deal(address(rewardsManager), 1 ether);
-
-        assertEq(T33D.balanceOf(address(rd)), 1_000e33);
-        assertEq(T33D.balanceOf(BOB), 0);
-
-        vm.startPrank(address(rewardsManager));
-        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, 10e18)); // Distribute 10 tokens, the number is in 18 dec precision
-        vm.stopPrank();
-
-        assertEq(T33D.balanceOf(address(rd)), 990e33);
-        assertEq(T33D.balanceOf(BOB), 10e33);
     }
 }


### PR DESCRIPTION
- When payout token has a different from 18 decimals precision, adjust payout amount to match
- Convert both ways: during `distributeRewards` we go from `X decimals` of rewards token -> to system's `18 dec` and on payout we do the opposite from system's `18 dec` -> to rewards token `X dec`
- Add extra tests and check payed/remainder amounts for tokens with 6 and 33 decimals precision during payout
- Add tests for distribute rewards to ensure `RewardsManagerModule` gets numbers in 18 dec only
