### PR TITLE
Rewards amount tracking and validation

### DIFF
--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -53,22 +53,28 @@ contract RewardsDistributorPrecisionTest is Test {
 
     function test_distributeRewards_lowerDecimalsToken() public {
         MintableToken T6D = new MintableToken("T6D", 6);
-        RewardsDistributor rd = new RewardsDistributor(
+        RewardsDistributor rewardsDistributor = new RewardsDistributor(
             address(rewardsManager),
             poolId,
             collateralType,
             address(T6D),
             "6 Decimals token payouts"
         );
-        T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
+        T6D.mint(address(rewardsDistributor), 1_000e6); // 1000 T6D tokens
 
-        assertEq(T6D.balanceOf(address(rd)), 1_000e6);
+        assertEq(T6D.balanceOf(address(rewardsDistributor)), 1_000e6);
         assertEq(T6D.balanceOf(BOB), 0);
 
-        uint256 amount = 100e6;
+        uint256 distributionAmount = 100e6;
 
         vm.startPrank(BOSS);
-        rd.distributeRewards(poolId, collateralType, amount, start, duration);
+        rewardsDistributor.distributeRewards(
+            poolId,
+            collateralType,
+            distributionAmount,
+            start,
+            duration
+        );
         vm.stopPrank();
 
         // check that rewards manager only deals with 18 decimals
@@ -77,7 +83,13 @@ contract RewardsDistributorPrecisionTest is Test {
         uint256 fractionAmount = 0.001e6;
 
         vm.startPrank(BOSS);
-        rd.distributeRewards(poolId, collateralType, fractionAmount, start, duration);
+        rewardsDistributor.distributeRewards(
+            poolId,
+            collateralType,
+            fractionAmount,
+            start,
+            duration
+        );
         vm.stopPrank();
 
         assertEq(rewardsManager.amount(), 0.001e18);
@@ -85,22 +97,28 @@ contract RewardsDistributorPrecisionTest is Test {
 
     function test_distributeRewards_higherDecimalsToken() public {
         MintableToken T33D = new MintableToken("T33D", 33);
-        RewardsDistributor rd = new RewardsDistributor(
+        RewardsDistributor rewardsDistributor = new RewardsDistributor(
             address(rewardsManager),
             poolId,
             collateralType,
             address(T33D),
             "33 Decimals token payouts"
         );
-        T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
+        T33D.mint(address(rewardsDistributor), 1_000e33); // 1000 T33D tokens
 
-        assertEq(T33D.balanceOf(address(rd)), 1_000e33);
+        assertEq(T33D.balanceOf(address(rewardsDistributor)), 1_000e33);
         assertEq(T33D.balanceOf(BOB), 0);
 
-        uint256 amount = 100e33;
+        uint256 distributionAmount = 100e33;
 
         vm.startPrank(BOSS);
-        rd.distributeRewards(poolId, collateralType, amount, start, duration);
+        rewardsDistributor.distributeRewards(
+            poolId,
+            collateralType,
+            distributionAmount,
+            start,
+            duration
+        );
         vm.stopPrank();
 
         // check that rewards manager only deals with 18 decimals
@@ -109,7 +127,13 @@ contract RewardsDistributorPrecisionTest is Test {
         uint256 fractionAmount = 0.001e33;
 
         vm.startPrank(BOSS);
-        rd.distributeRewards(poolId, collateralType, fractionAmount, start, duration);
+        rewardsDistributor.distributeRewards(
+            poolId,
+            collateralType,
+            fractionAmount,
+            start,
+            duration
+        );
         vm.stopPrank();
 
         assertEq(rewardsManager.amount(), 0.001e18);
@@ -117,49 +141,77 @@ contract RewardsDistributorPrecisionTest is Test {
 
     function test_payout_lowerDecimalsToken() public {
         MintableToken T6D = new MintableToken("T6D", 6);
-        RewardsDistributor rd = new RewardsDistributor(
+        RewardsDistributor rewardsDistributor = new RewardsDistributor(
             address(rewardsManager),
             poolId,
             collateralType,
             address(T6D),
             "6 Decimals token payouts"
         );
-        T6D.mint(address(rd), 1_000e6); // 1000 T6D tokens
+        T6D.mint(address(rewardsDistributor), 1_000e6); // 1000 T6D tokens
 
-        assertEq(T6D.balanceOf(address(rd)), 1_000e6);
+        assertEq(T6D.balanceOf(address(rewardsDistributor)), 1_000e6);
         assertEq(T6D.balanceOf(BOB), 0);
 
-        uint256 amount = 10e18; // Distribute 10 tokens, the number is in 18 dec precision
+        // Distribute 100 tokens, the number is in 6 dec precision, because it is called by pool owner BOSS
+        uint256 distributionAmount = 100e6;
 
-        vm.startPrank(address(rewardsManager));
-        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, amount));
+        vm.startPrank(BOSS);
+        rewardsDistributor.distributeRewards(
+            poolId,
+            collateralType,
+            distributionAmount,
+            start,
+            duration
+        );
         vm.stopPrank();
 
-        assertEq(T6D.balanceOf(address(rd)), 990e6);
+        // Pay 10 tokens to BOB, the number is in 18 dec precision because it is called by Core
+        uint256 payoutAmount = 10e18;
+
+        vm.startPrank(address(rewardsManager));
+        assertTrue(rewardsDistributor.payout(accountId, poolId, collateralType, BOB, payoutAmount));
+        vm.stopPrank();
+
+        assertEq(T6D.balanceOf(address(rewardsDistributor)), 990e6);
         assertEq(T6D.balanceOf(BOB), 10e6);
     }
 
     function test_payout_higherDecimalsToken() public {
         MintableToken T33D = new MintableToken("T33D", 33);
-        RewardsDistributor rd = new RewardsDistributor(
+        RewardsDistributor rewardsDistributor = new RewardsDistributor(
             address(rewardsManager),
             poolId,
             collateralType,
             address(T33D),
             "33 Decimals token payouts"
         );
-        T33D.mint(address(rd), 1_000e33); // 1000 T33D tokens
+        T33D.mint(address(rewardsDistributor), 1_000e33); // 1000 T33D tokens
 
-        assertEq(T33D.balanceOf(address(rd)), 1_000e33);
+        assertEq(T33D.balanceOf(address(rewardsDistributor)), 1_000e33);
         assertEq(T33D.balanceOf(BOB), 0);
 
-        uint256 amount = 10e18; // Distribute 10 tokens, the number is in 18 dec precision
+        // Distribute 100 tokens, the number is in 33 dec precision, because it is called by pool owner BOSS
+        uint256 distributionAmount = 100e33;
 
-        vm.startPrank(address(rewardsManager));
-        assertTrue(rd.payout(accountId, poolId, collateralType, BOB, amount));
+        vm.startPrank(BOSS);
+        rewardsDistributor.distributeRewards(
+            poolId,
+            collateralType,
+            distributionAmount,
+            start,
+            duration
+        );
         vm.stopPrank();
 
-        assertEq(T33D.balanceOf(address(rd)), 990e33);
+        // Pay 10 tokens to BOB, the number is in 18 dec precision because it is called by Core
+        uint256 payoutAmount = 10e18;
+
+        vm.startPrank(address(rewardsManager));
+        assertTrue(rewardsDistributor.payout(accountId, poolId, collateralType, BOB, payoutAmount));
+        vm.stopPrank();
+
+        assertEq(T33D.balanceOf(address(rewardsDistributor)), 990e33);
         assertEq(T33D.balanceOf(BOB), 10e33);
     }
 }

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.21;
 
 import {Test} from "forge-std/Test.sol";
-import {MockERC20} from "forge-std/mocks/MockERC20.sol";
 import {RewardsDistributor} from "../src/RewardsDistributor.sol";
 
 import {MintableToken} from "./MintableToken.sol";

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -182,8 +182,7 @@ contract RewardsDistributorTest is Test {
         SNX.mint(address(rewardsDistributor), 1000e18);
 
         uint256 amount = 100e18;
-        uint64 start = 12345678;
-        uint32 duration = 3600;
+
         vm.startPrank(BOSS);
         rewardsDistributor.distributeRewards(poolId, collateralType, amount, start, duration);
         vm.stopPrank();
@@ -237,7 +236,23 @@ contract RewardsDistributorTest is Test {
         vm.stopPrank();
     }
 
+    function test_distributeRewards_NotEnoughBalance() public {
+        SNX.mint(address(rewardsDistributor), 1_000e18);
+
+        uint256 amount = 2_000e18; // try distributing 2_000 SNX, while having only 1_000 on balance
+
+        vm.expectRevert(
+            abi.encodeWithSelector(RewardsDistributor.NotEnoughBalance.selector, 2_000e18, 1_000e18)
+        );
+
+        vm.startPrank(BOSS);
+        rewardsDistributor.distributeRewards(poolId, collateralType, amount, start, duration);
+        vm.stopPrank();
+    }
+
     function test_distributeRewards() public {
+        SNX.mint(address(rewardsDistributor), 1_000e18);
+
         uint256 amount = 100e18;
 
         vm.startPrank(BOSS);

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -2,13 +2,10 @@
 pragma solidity ^0.8.21;
 
 import {Test} from "forge-std/Test.sol";
-import {MockERC20} from "forge-std/mocks/MockERC20.sol";
 import {RewardsDistributor} from "../src/RewardsDistributor.sol";
-import {IRewardsManagerModule} from "@synthetixio/main/contracts/interfaces/IRewardsManagerModule.sol";
 import {IRewardDistributor} from "@synthetixio/main/contracts/interfaces/external/IRewardDistributor.sol";
 import {AccessError} from "@synthetixio/core-contracts/contracts/errors/AccessError.sol";
 import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
-import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 
 import {MintableToken} from "./MintableToken.sol";
 
@@ -161,12 +158,7 @@ contract RewardsDistributorTest is Test {
 
     function test_payout_underflow() public {
         vm.expectRevert(
-            abi.encodeWithSelector(
-                ERC20Helper.FailedTransfer.selector,
-                address(rewardsDistributor),
-                BOB,
-                10e18
-            )
+            abi.encodeWithSelector(RewardsDistributor.NotEnoughRewardsLeft.selector, 10e18, 0)
         );
 
         vm.startPrank(address(rewardsManager));
@@ -188,6 +180,13 @@ contract RewardsDistributorTest is Test {
 
     function test_payout() public {
         SNX.mint(address(rewardsDistributor), 1000e18);
+
+        uint256 amount = 100e18;
+        uint64 start = 12345678;
+        uint32 duration = 3600;
+        vm.startPrank(BOSS);
+        rewardsDistributor.distributeRewards(poolId, collateralType, amount, start, duration);
+        vm.stopPrank();
 
         vm.startPrank(address(rewardsManager));
         assertTrue(rewardsDistributor.payout(accountId, poolId, collateralType, BOB, 10e18));


### PR DESCRIPTION
- Track rewards amount and prevent claiming more than there is left to distribute
- Validate that rewards distributor has enough balance when distributing rewards

NOTE: as all interactions with RewardsDistributor from outside are happening in payoutToken precision, `rewardsAmount` is also intended to be tracking values in `payoutToken` precision. The same rule applies to events: `NotEnoughRewardsLeft` and `NotEnoughBalance`. 