### PR TITLE
Specify payout token decimals

### DIFF
--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -34,6 +34,7 @@ contract RewardsDistributor is IRewardDistributor {
         uint128 poolId_,
         address collateralType_,
         address payoutToken_,
+        uint8 payoutTokenDecimals_,
         string memory name_
     ) {
         rewardManager = rewardManager_; // Synthetix CoreProxy
@@ -41,7 +42,19 @@ contract RewardsDistributor is IRewardDistributor {
         collateralType = collateralType_;
         payoutToken = payoutToken_;
         name = name_;
-        precision = 10 ** IERC20(payoutToken_).decimals();
+
+        try IERC20(payoutToken_).decimals() returns (uint8 decimals) {
+            if (payoutTokenDecimals_ != decimals) {
+                revert ParameterError.InvalidParameter(
+                    "payoutTokenDecimals",
+                    "Specified token decimals do not match actual token decimals"
+                );
+            }
+            precision = 10 ** decimals;
+        } catch {
+            // Fallback to the specified token decimals skipping the check if token does not support decimals method
+            precision = 10 ** payoutTokenDecimals_;
+        }
     }
 
     function token() public view returns (address) {

--- a/src/RewardsDistributor.sol
+++ b/src/RewardsDistributor.sol
@@ -43,18 +43,18 @@ contract RewardsDistributor is IRewardDistributor {
         payoutToken = payoutToken_;
         name = name_;
 
-        try IERC20(payoutToken_).decimals() returns (uint8 decimals) {
-            if (payoutTokenDecimals_ != decimals) {
-                revert ParameterError.InvalidParameter(
-                    "payoutTokenDecimals",
-                    "Specified token decimals do not match actual token decimals"
-                );
-            }
-            precision = 10 ** decimals;
-        } catch {
-            // Fallback to the specified token decimals skipping the check if token does not support decimals method
-            precision = 10 ** payoutTokenDecimals_;
+        (bool success, bytes memory data) = payoutToken_.call(
+            abi.encodeWithSignature("decimals()")
+        );
+
+        if (success && data.length > 0 && abi.decode(data, (uint8)) != payoutTokenDecimals_) {
+            revert ParameterError.InvalidParameter(
+                "payoutTokenDecimals",
+                "Specified token decimals do not match actual token decimals"
+            );
         }
+        // Fallback to the specified token decimals skipping the check if token does not support decimals method
+        precision = 10 ** payoutTokenDecimals_;
     }
 
     function token() public view returns (address) {

--- a/test/RewardsDistributorConstructorTest.sol
+++ b/test/RewardsDistributorConstructorTest.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {RewardsDistributor} from "../src/RewardsDistributor.sol";
+import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
+import {MintableToken} from "./MintableToken.sol";
+
+contract EmptyContract {
+    // empty
+}
+
+contract RewardsDistributorConstructorTest is Test {
+    address private BOB;
+    address private BOSS;
+
+    MintableToken internal sUSDC;
+    EmptyContract internal rewardsManager;
+
+    uint128 internal accountId = 1;
+    uint128 internal poolId = 1;
+    address internal collateralType;
+    uint64 internal start = 12345678;
+    uint32 internal duration = 3600;
+
+    function setUp() public {
+        BOB = vm.addr(0xB0B);
+        rewardsManager = new EmptyContract();
+        sUSDC = new MintableToken("sUSDC", 18);
+        collateralType = address(sUSDC);
+    }
+
+    function test_constructor_wrongDecimalsSpecified() public {
+        MintableToken T6D = new MintableToken("T6D", 6);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ParameterError.InvalidParameter.selector,
+                "payoutTokenDecimals",
+                "Specified token decimals do not match actual token decimals"
+            )
+        );
+
+        new RewardsDistributor(
+            address(rewardsManager),
+            poolId,
+            collateralType,
+            address(T6D),
+            18, // not matching the token 6 decimals
+            "6 Decimals token payouts"
+        );
+    }
+
+    function test_constructor_noDecimalsToken() public {
+        EmptyContract TKN = new EmptyContract();
+        RewardsDistributor rewardsDistributor = new RewardsDistributor(
+            address(rewardsManager),
+            poolId,
+            collateralType,
+            address(TKN),
+            18,
+            "18 Decimals token payouts"
+        );
+        assertEq(rewardsDistributor.precision(), 10 ** 18);
+    }
+}

--- a/test/RewardsDistributorPrecisionTest.sol
+++ b/test/RewardsDistributorPrecisionTest.sol
@@ -58,6 +58,7 @@ contract RewardsDistributorPrecisionTest is Test {
             poolId,
             collateralType,
             address(T6D),
+            T6D.decimals(),
             "6 Decimals token payouts"
         );
         T6D.mint(address(rewardsDistributor), 1_000e6); // 1000 T6D tokens
@@ -102,6 +103,7 @@ contract RewardsDistributorPrecisionTest is Test {
             poolId,
             collateralType,
             address(T33D),
+            T33D.decimals(),
             "33 Decimals token payouts"
         );
         T33D.mint(address(rewardsDistributor), 1_000e33); // 1000 T33D tokens
@@ -146,6 +148,7 @@ contract RewardsDistributorPrecisionTest is Test {
             poolId,
             collateralType,
             address(T6D),
+            T6D.decimals(),
             "6 Decimals token payouts"
         );
         T6D.mint(address(rewardsDistributor), 1_000e6); // 1000 T6D tokens
@@ -184,6 +187,7 @@ contract RewardsDistributorPrecisionTest is Test {
             poolId,
             collateralType,
             address(T33D),
+            T33D.decimals(),
             "33 Decimals token payouts"
         );
         T33D.mint(address(rewardsDistributor), 1_000e33); // 1000 T33D tokens

--- a/test/RewardsDistributorTest.sol
+++ b/test/RewardsDistributorTest.sol
@@ -77,6 +77,7 @@ contract RewardsDistributorTest is Test {
             poolId,
             collateralType,
             payoutToken,
+            SNX.decimals(),
             name
         );
     }


### PR DESCRIPTION
Add payoutTokenDecimals constructor argument to support tokens that do not have decimals() method.